### PR TITLE
Update Height of ListItem.Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/ListItem/index.js
+++ b/src/ListItem/index.js
@@ -79,10 +79,10 @@ const Link = styled(BaseBox)`
 
 Link.defaultProps = {
   alignItems: 'center',
+  alignSelf: 'stretch',
   borderColor: 'grays.2',
   borderLeft: '1px solid',
   display: 'flex',
-  height: '100%',
   justifyContent: 'center',
   px,
   py,


### PR DESCRIPTION
### Summary

Update List Item Link to use align self instead of height: 100% to make it stretch properly.

### Definition of Done

- [x] All comments and debug statements have been removed
- [x] Unit and integration tests for Ruby code
- [x] Snapshot tests and DOM assertions for React components, unit tests for Javascript
- [x] Design reviewed
- [x] Feature is tested against acceptance criteria
- [x] Any configuration or build changes documented
- [x] Environment variables are added or removed according to the [documentation](https://github.com/nextglass/utfb/wiki/PR-Apps:-Adding-new-environment-variables)
