### PR TITLE
UTM-629: Add notes icon

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -414,6 +414,7 @@ class Examples extends Component {
           <Icons.Disclosure />
           <Icons.Close />
           <Icons.CloseCircle />
+          <Icons.Notes />
           <Icons.Search />
           <Icons.Trashcan />
           <Icons.Edit />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/Icons/index.js
+++ b/src/Icons/index.js
@@ -1,25 +1,27 @@
+import Alert from './alert.svg'
+import Checked from './checked.svg'
 import Close from './close.svg'
 import CloseCircle from './close-circle.svg'
 import Disclosure from './disclosure.svg'
-import Search from './search.svg'
-import Alert from './alert.svg'
-import Checked from './checked.svg'
-import Info from './info.svg'
-import Trashcan from './trashcan.svg'
 import Edit from './edit.svg'
-import Print from './print.svg'
 import Export from './export.svg'
+import Info from './info.svg'
+import Notes from './notes.svg'
+import Print from './print.svg'
+import Search from './search.svg'
+import Trashcan from './trashcan.svg'
 
 export default {
+  Alert,
   Close,
-  Disclosure,
-  Search,
   CloseCircle,
   Checked,
-  Info,
-  Alert,
-  Trashcan,
+  Disclosure,
   Edit,
-  Print,
   Export,
+  Info,
+  Notes,
+  Print,
+  Search,
+  Trashcan,
 }

--- a/src/Icons/notes.svg
+++ b/src/Icons/notes.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" fill="none"/>
+<path d="M13.5 15V20.5H12H4.5V3.5H19.5V11.4375V14.5H14H13.5V15Z" stroke="#898989"/>
+<path d="M4.5 3.5H19.5V11.4375V14.7929L16.6464 17.6464L13.7929 20.5H12H4.5V3.5Z" stroke="#898989"/>
+<rect x="7" y="6" width="10" height="1" fill="#898989"/>
+<rect x="7" y="9" width="10" height="1" fill="#898989"/>
+<rect x="7" y="12" width="10" height="1" fill="#898989"/>
+</svg>


### PR DESCRIPTION
### Summary

Adding a new notes icon to be used in Marketplace.

### Testing
- Fire up ye olde app `yarn && yarn start` at root
- Scroll down to the Icons section
- Bask in the glow of the new notes Icon (a paper with a folder upper right corner) 🗒 
