### PR TITLE
Update hover button colors to be explicitly white

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -12,6 +12,7 @@ const blue = css`
   &:hover {
     background-color: ${getColor('darkBlue')};
     border-color: ${getColor('darkBlue')};
+    color: ${getColor('white')};
   }
 `
 
@@ -22,6 +23,7 @@ const red = css`
   &:hover {
     border-color: ${getColor('darkRed')};
     background-color: ${getColor('darkRed')};
+    color: ${getColor('white')};
   }
 `
 
@@ -32,6 +34,7 @@ const green = css`
   &:hover {
     background-color: ${getColor('darkGreen')};
     border-color: ${getColor('darkGreen')};
+    color: ${getColor('white')};
   }
 `
 


### PR DESCRIPTION
### Summary

Updates the hover states of the buttons to have an explicitly white text color on hover. We were seeing an issue where a tags styled like buttons were getting Foundation styles for the text color on hover, resulting in buttons looking like this.

![image](https://user-images.githubusercontent.com/10661479/65265763-99898700-dadf-11e9-9fe9-31c636f57518.png)

This change will be more specific than the foundation style, and fix the readability issue on hover.

This is the new hover state in the untappd components examples:

![image](https://user-images.githubusercontent.com/10661479/65265827-c9d12580-dadf-11e9-8545-9f186c328969.png)


### Definition of Done

- [x] All comments and debug statements have been removed
- [x] Unit and integration tests for Ruby code
- [x] Snapshot tests and DOM assertions for React components, unit tests for Javascript
- [x] Design reviewed
- [x] Feature is tested against acceptance criteria
- [x] Any configuration or build changes documented
- [x] Environment variables are added or removed according to the [documentation](https://github.com/nextglass/utfb/wiki/PR-Apps:-Adding-new-environment-variables)
