### PR TITLE
Update z-index on Select and Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.4.0-alpha.0",
+  "version": "1.4.1-alpha.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -39,7 +39,7 @@ export const StyledModal = styled(ReactModalAdapter)`
     right: 0;
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.6);
-    z-index: 40;
+    z-index: 100000000;
   }
 
   &__content ${Card} {

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -39,7 +39,7 @@ export const StyledModal = styled(ReactModalAdapter)`
     right: 0;
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.6);
-    z-index: 4;
+    z-index: 40;
   }
 
   &__content ${Card} {

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -16,6 +16,10 @@ const sharedStyle = css`
     border-color: ${t('colors.grays.2')};
   }
 
+  .ut-select__menu {
+    z-index: 20;
+  }
+
   .ut-select__control--is-focused {
     border-color: ${getColor('grays.3')};
     box-shadow: none;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -17,7 +17,7 @@ const sharedStyle = css`
   }
 
   .ut-select__menu {
-    z-index: 20;
+    z-index: 10000000;
   }
 
   .ut-select__control--is-focused {


### PR DESCRIPTION
### Summary
This increases the z-index for the select dropdown so that it covers other components on the page.

Currently, it has a z-index of 1, which only covers items with no z-index set. For any overlay, it will fall behind, like we have here in Marketplace.

![image](https://user-images.githubusercontent.com/10661479/72102815-de873280-32f5-11ea-8fe2-f0778889c0fc.png)

I've also upped the value on the modal (the only other component we set a z-index on) so that it is higher than the select in case they should ever collide.

### Definition of Done

- [x] All comments and debug statements have been removed
- [x] Unit and integration tests for Ruby code
- [x] Snapshot tests and DOM assertions for React components, unit tests for Javascript
- [x] Design reviewed
- [x] Feature is tested against acceptance criteria
- [x] Any configuration or build changes documented
- [x] Environment variables are added or removed according to the [documentation](https://github.com/nextglass/utfb/wiki/PR-Apps:-Adding-new-environment-variables)
