### PR TITLE
Autocomplete: Pass onBlur to the SearchInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.4.1-alpha.0",
+  "version": "1.4.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/Autocomplete/index.js
+++ b/src/Autocomplete/index.js
@@ -43,6 +43,7 @@ function Autocomplete({
   renderItem,
   infoRender,
   theme,
+  onBlur,
   ...props
 }) {
   return (
@@ -62,6 +63,7 @@ function Autocomplete({
           <SearchInput
             {...getInputProps({
               placeholder,
+              onBlur,
             })}
           />
 


### PR DESCRIPTION
### Summary

Adds an `onBlur` prop to the `Autocomplete` component which is passed through to the `SearchInput`. This is needed as Downshift does not have an `onBlur` prop and we are required to send our own through to the input.

This functionality is needed in Nüwoof so that Formik can mark the field as touched properly when the user enters the field and then leaves

### Definition of Done

- [x] All comments and debug statements have been removed
- [x] Unit and integration tests for Ruby code
- [x] Snapshot tests and DOM assertions for React components, unit tests for Javascript
- [x] Design reviewed
- [x] Feature is tested against acceptance criteria
- [x] Any configuration or build changes documented
- [x] Environment variables are added or removed according to the [documentation](https://github.com/nextglass/utfb/wiki/PR-Apps:-Adding-new-environment-variables)
