### PR TITLE
Update the style for a disabled select box

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -135,6 +135,7 @@ class Examples extends Component {
     items: ITEMS,
     asyncInputValue: '',
     selectedOption: null,
+    selectedOptionDisabled: options[1],
     isToggle1Checked: false,
     isToggle2Checked: true,
   }
@@ -146,6 +147,7 @@ class Examples extends Component {
       isFixedWidthModalOpen,
       isLoading,
       selectedOption,
+      selectedOptionDisabled,
       asyncInputValue,
       isToggle1Checked,
       isToggle2Checked,
@@ -367,6 +369,15 @@ class Examples extends Component {
                 selectedOption: value,
               })
             }}
+          />
+          <br />
+
+          <FormLabel htmlFor="select-box">Select Box (disabled)</FormLabel>
+          <Select
+            id="select-box"
+            value={selectedOptionDisabled}
+            options={options}
+            isDisabled
           />
 
           <Text mt={1}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@untappd/components",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "license": "MIT",

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -29,6 +29,13 @@ const sharedStyle = css`
     }
   }
 
+  .ut-select__control--is-disabled {
+    background-color: ${getColor('grays.2')};
+    border-color: ${getColor('grays.3')};
+    opacity: 0.25;
+  }
+  }
+
   .ut-select__single-value {
     color: ${t('colors.black')};
   }

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -34,7 +34,6 @@ const sharedStyle = css`
     border-color: ${getColor('grays.3')};
     opacity: 0.25;
   }
-  }
 
   .ut-select__single-value {
     color: ${t('colors.black')};


### PR DESCRIPTION
## Summary
Updates the style for a `Select` when it has been disabled to match the style for a disabled `TextInput`

**Old**
![Screen Shot 2020-07-07 at 2 19 40 PM](https://user-images.githubusercontent.com/451249/86825208-17ae1e80-c05d-11ea-9bc7-411571f5157b.png)

**New**
![Screen Shot 2020-07-07 at 2 19 51 PM](https://user-images.githubusercontent.com/451249/86825219-1aa90f00-c05d-11ea-94fa-c824b4f546fd.png)


## Testing
I added a disabled `Select` input to the examples section that demonstrates this. Verify the `Select` matches the disabled `TextInput` and continues to operate as expected
